### PR TITLE
Update validate types

### DIFF
--- a/dist/generator.d.ts
+++ b/dist/generator.d.ts
@@ -1,0 +1,8 @@
+import { Validation } from './index';
+declare type Fields<T> = {
+    key: keyof T;
+    rule?: any;
+    msg?: string;
+};
+export declare const generateContract: <T extends Object>(fields: Fields<T>[]) => Validation<Partial<T>>[];
+export {};

--- a/dist/generator.js
+++ b/dist/generator.js
@@ -1,0 +1,18 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.generateContract = void 0;
+const required_1 = __importDefault(require("./rules/required"));
+exports.generateContract = (fields) => {
+    return fields.map(({ key, rule, msg }) => ({
+        key: key,
+        promises: [
+            {
+                msg: () => msg !== null && msg !== void 0 ? msg : '* Required',
+                rule: rule !== null && rule !== void 0 ? rule : required_1.default,
+            },
+        ],
+    }));
+};

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -22,7 +22,7 @@ export { shorterThan } from './rules/shorterThan';
 export { longerThan } from './rules/longerThan';
 export declare type ArgFunc<T extends object, R> = (value: string, row: T) => R;
 export declare type MsgFunc<T extends object, A = any> = (value: string, row: T, arg?: A | ArgFunc<T, A>) => string;
-export declare type ValidationPromise<T extends object = object, A = any> = (value: string | string[] | Record<string, number | string> | number | Date, row: T, msg: MsgFunc<T, A>, arg?: A | ArgFunc<T, A>) => Promise<string | void>;
+export declare type ValidationPromise<T extends object = object, A = any, V = any> = (value: V, row: T, msg: MsgFunc<T, A>, arg?: A | ArgFunc<T, A>) => Promise<string | void>;
 interface IAPromise<T extends object = object> {
     rule: ValidationPromise<T>;
     arg?: (value?: string, row?: T) => any;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -22,7 +22,7 @@ export { shorterThan } from './rules/shorterThan';
 export { longerThan } from './rules/longerThan';
 export declare type ArgFunc<T extends object, R> = (value: string, row: T) => R;
 export declare type MsgFunc<T extends object, A = any> = (value: string, row: T, arg?: A | ArgFunc<T, A>) => string;
-export declare type ValidationPromise<T extends object = object, A = any> = (value: string | string[] | Record<string, number> | number | Date, row: T, msg: MsgFunc<T, A>, arg?: A | ArgFunc<T, A>) => Promise<string | void>;
+export declare type ValidationPromise<T extends object = object, A = any> = (value: string | string[] | Record<string, number | string> | number | Date, row: T, msg: MsgFunc<T, A>, arg?: A | ArgFunc<T, A>) => Promise<string | void>;
 interface IAPromise<T extends object = object> {
     rule: ValidationPromise<T>;
     arg?: (value?: string, row?: T) => any;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "validate-promise",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "validate-promise",
-      "version": "3.8.0",
+      "version": "3.8.2",
       "license": "MIT",
       "dependencies": {
         "is-email": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "validate-promise",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "description": "Promised based validation library",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ export type ArgFunc<T extends object, R> = (value: string, row: T) => R;
 export type MsgFunc<T extends object, A = any> = (value: string, row: T, arg?: A | ArgFunc<T, A>) => string;
 
 
-export type ValidationPromise<T extends object = object, A = any, V = any> = (
+export type ValidationPromise<T extends object = object, A = any, V = string | string[] | Record<string, number> | number | Date> = (
   value: V,
   row: T,
   msg: MsgFunc<T, A>,

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ export type MsgFunc<T extends object, A = any> = (value: string, row: T, arg?: A
 
 
 export type ValidationPromise<T extends object = object, A = any> = (
-  value: string | string[] | Record<string, number> | number | Date,
+  value: string | string[] | Record<string, number | string> | number | Date,
   row: T,
   msg: MsgFunc<T, A>,
   arg?: A | ArgFunc<T, A>,

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,8 +37,8 @@ export type ArgFunc<T extends object, R> = (value: string, row: T) => R;
 export type MsgFunc<T extends object, A = any> = (value: string, row: T, arg?: A | ArgFunc<T, A>) => string;
 
 
-export type ValidationPromise<T extends object = object, A = any> = (
-  value: string | string[] | Record<string, number | string> | number | Date,
+export type ValidationPromise<T extends object = object, A = any, V = any> = (
+  value: V,
   row: T,
   msg: MsgFunc<T, A>,
   arg?: A | ArgFunc<T, A>,


### PR DESCRIPTION
Adds a template value for the validate promise type. This will allow people to specify the types when creating custom validator functions.

Notes for reviewers:

I don't think this is a breaking change, and it's just updating a type so I've made it a patch. Thought technically it's a feature so maybe it should be a minor version?